### PR TITLE
Pip install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ In order for the monitor to work, you must have [Python 3+](https://www.python.o
 
 `git clone https://github.com/walmat/Off-White-Monitor.git`<br>
 `cd Off-White-Monitor`<br>
+`pip install requirements.txt`<br>
 `python3 main.py`
 
 Since you're most likely using Slack/Discord for notifications, go ahead and rename the file `config.sample.json` to `config.json`. Then open that file in whatever text editor you prefer and paste in your webhook tokens inside of the empty strings.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+beautifulsoup4==4.7.1
+bs4==0.0.1
+certifi==2018.11.29
+chardet==3.0.4
+idna==2.8
+requests==2.21.0
+soupsieve==1.7.3
+urllib3==1.24.1


### PR DESCRIPTION
Allow users to pip install the dependencies by `pip install requirements.txt` before `python3 main.py`